### PR TITLE
fix command and arguments splitting

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -572,7 +572,8 @@ func (s *Slack) findParams(wrapper bool, command string, params []string, m *sla
 	}
 
 	text, command := s.getEventTextCommand(command, m)
-	arr := strings.SplitAfter(text, command)
+	delimiter := command + " "
+	arr := strings.SplitN(text, delimiter, 2)
 	if len(arr) < 2 {
 		return r, rw, nil, ""
 	}


### PR DESCRIPTION
if arguments "app blabla-approver" then we split it incorrectly as "app" "blabla-app" "rover"