### PR TITLE
Updates to use commands with default values in cli mode

### DIFF
--- a/common/processor.go
+++ b/common/processor.go
@@ -17,6 +17,7 @@ type Message interface {
 	Visible() bool
 	User() User
 	Channel() Channel
+	ParentID() string
 }
 
 type AttachmentType string
@@ -61,6 +62,7 @@ type Command interface {
 	Params() []string
 	Aliases() []string
 	Fields(bot Bot, message Message) []Field
+	ParamsSetDefaults(params map[string]interface{}, fields []Field) map[string]interface{}
 	Priority() int
 	Wrapper() bool
 	Schedule() string

--- a/processor/default.go
+++ b/processor/default.go
@@ -13,6 +13,7 @@ import (
 	sreCommon "github.com/devopsext/sre/common"
 	toolsRender "github.com/devopsext/tools/render"
 	"github.com/devopsext/utils"
+	"github.com/jinzhu/copier"
 	"gopkg.in/yaml.v2"
 )
 
@@ -670,6 +671,19 @@ func (dc *DefaultCommand) Fields(bot common.Bot, message common.Message) []commo
 		return newFields
 	}
 	return []common.Field{}
+}
+
+func (dc *DefaultCommand) ParamsSetDefaults(eParams map[string]interface{}, fields []common.Field) map[string]interface{} {
+	newParams := make(map[string]interface{})
+	copier.Copy(&newParams,eParams)
+	for _, field := range fields {
+		if !utils.IsEmpty(eParams[field.Name]) {
+			newParams[field.Name] = eParams[field.Name]
+		} else if !utils.IsEmpty(field.Default) {
+			newParams[field.Name] = fmt.Sprintf("%v", field.Default)
+		}
+	}
+	return newParams
 }
 
 func (dc *DefaultCommand) Priority() int {


### PR DESCRIPTION
export ParentID (threadtimestamp),
aux func to set defaults in params,
setting defaults in params if field has default (both hardcoded and from templates that return "default" in json) for cli calls to work properly