### PR TITLE
Implement message reply capability in Slack

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -204,6 +204,10 @@ func (sm *SlackMessage) ParentID() string {
 	return sm.threadTimestamp
 }
 
+func (sm *SlackMessage) SetID(id string) {
+	sm.id = id
+}
+
 // Slack
 
 func (s *Slack) Name() string {
@@ -1344,15 +1348,13 @@ func (s *Slack) hideInteraction(m *slackMessageInfo, responseURL string) {
 	)
 }
 
-func (s *Slack) Post(channel string, message string, attachments []*common.Attachment, parent common.Message) error {
-
+func (s *Slack) Post(channel, message string, attachments []*common.Attachment, parent common.Message) (string, error) {
 	channelID := channel
 	threadTS := ""
 	visible := true
 	userID := ""
 
-	if !utils.IsEmpty(parent) {
-
+	if parent != nil {
 		threadTS = parent.ID()
 		p, ok := parent.(*SlackMessage)
 		if ok {
@@ -1371,7 +1373,7 @@ func (s *Slack) Post(channel string, message string, attachments []*common.Attac
 
 	atts, err := s.buildAttachmentBlocks(attachments)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	blocks := []slack.Block{}
@@ -1393,8 +1395,8 @@ func (s *Slack) Post(channel string, message string, attachments []*common.Attac
 	}
 
 	client := s.client.SlackClient()
-	_, _, err = client.PostMessage(channelID, options...)
-	return err
+	_, ts, err := client.PostMessage(channelID, options...)
+	return ts, err
 }
 
 func (s *Slack) interactionDefinition(cmd common.Command, group string) *slacker.InteractionDefinition {

--- a/common/bot.go
+++ b/common/bot.go
@@ -9,7 +9,7 @@ import (
 type Bot interface {
 	Start(wg *sync.WaitGroup)
 	Name() string
-	Post(channel string, message string, attachments []*Attachment, parent Message) error
+	Post(channel string, message string, attachments []*Attachment, parent Message) (string, error)
 	Delete(channel, message string) error
 }
 


### PR DESCRIPTION
List of changes in this PR:

In `bot/slack.go`:
- Added `SetID` method to the `SlackMessage` struct, to be able to define the ID of the parent message outside the bot package, which enables us to reply to an arbitrary thread.
- Fixed how `parent common.Message` is evaluated as nil. Because `parent` is a struct, you cannot use `utils.IsEmpty()` with it, because it will call `reflect.Value.IsNil()` and that function direclty panics when you pass a struct to it, so this was a bug. Now we simply check if `parent != nil`

In `common/bot.go`:
- Now the `Post()` method of the `Bot` interface must also return a string. This string is the identifier of the posted message (message ID in Telegram or message timestamp in Slack for example), and this identifier can be used to add replies to said message.

In `processor/default.go`:
- Added `fSendMessageWithAttachment()` function to be able to send attachments from inside the Go templates.
- Added `threadTS` optional parameter to `fSendMessage()` which can be used to post the message as a reply.


Maybe a question about the last file will be, why was `fSendMessageWithAttachment()` created when we have `fSendMessageEx()`? 
The answer is that I don't know the intentions behind `fSendMessageEx()`, or if it is a work-in-progress, but it's currently useless. If you take a look at `fSendMessageEx()`, it tries to cast an `attachment` interface object coming from the template into a `*common.Attachment` struct, which I believe it's impossible.