### PR TITLE
Enable parent subposts

### DIFF
--- a/common/bot.go
+++ b/common/bot.go
@@ -17,6 +17,7 @@ type Bot interface {
 	DeleteMessage(channel, ID string) error
 	ReadMessage(channel, ID string) (string, error)
 	UpdateMessage(channel, ID, text string) error
+	GetLastMessageID(channelID string) (string, error)
 }
 
 type Bots struct {


### PR DESCRIPTION
A small rework on defaultAfter and After functions to allow distinguishing between different subposts after posting the main command. The result is the ability to have different postTemplates inside templates posted in different threads, such as:
```
├── rootCmd
│   ├── parentTemplate1
│   │   ├── childrenTemplate1
│   ├── parentTemplate2
│   │   ├── childrenTemplateN
```

The postTemplateParent has also been added to explicitly post templates in different threads.