### PR TITLE
Guards against nil message keys

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -292,6 +292,10 @@ func (sc *SlackChannel) ID() string {
 // SlackMessage
 
 func (sm *SlackMessage) ID() string {
+	if sm.key == nil {
+		return ""
+	}
+
 	return sm.key.timestamp
 }
 
@@ -317,14 +321,23 @@ func (sm *SlackMessage) userID() string {
 }
 
 func (sm *SlackMessage) Channel() common.Channel {
+	if sm.key == nil {
+		return nil
+	}
 	return &SlackChannel{id: sm.key.channelID}
 }
 
 func (sm *SlackMessage) ParentID() string {
+	if sm.key == nil {
+		return ""
+	}
 	return sm.key.threadTS
 }
 
 func (sm *SlackMessage) SetParentID(threadTS string) {
+	if sm.key == nil {
+		return
+	}
 	sm.key.threadTS = threadTS
 }
 
@@ -2773,6 +2786,7 @@ func (s *Slack) Command(channel, text string, user common.User, parent common.Me
 func (s *Slack) PostMessage(channel string, message string, attachments []*common.Attachment, actions []common.Action,
 	user common.User, parent common.Message, response common.Response) (string, error) {
 
+	/* if we don;t have parrent message, post message should process it properly and take origin properties, not it doesn't know where to send postmessages */
 	channelID := channel
 	threadTS := ""
 	userID := ""

--- a/processor/default.go
+++ b/processor/default.go
@@ -188,7 +188,7 @@ func (de *DefaultExecutor) Visible() bool {
 	if de.visible != nil {
 		return *de.visible
 	}
-	if de.message != nil {
+	if !utils.IsEmpty(de.message) {
 		return de.message.Visible()
 	}
 	return false
@@ -722,7 +722,7 @@ func (de *DefaultExecutor) execute(id string, obj interface{}, message common.Me
 
 			// set real message which appears after first execution
 			m["message"] = message
-			if message != nil {
+			if !utils.IsEmpty(message) {
 				m["channel"] = message.Channel()
 				m["user"] = message.User()
 				m["caller"] = message.Caller()


### PR DESCRIPTION
Adds nil checks for SlackMessage keys to prevent panics when accessing properties on nil keys.