### PR TITLE
Thread PostMessages to the original ParentID() if threadTS is not set

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -2843,6 +2843,9 @@ func (s *Slack) PostMessage(channel string, message string, attachments []*commo
 				}
 				threadTS = mOrigin.key.threadTS
 			}
+			if utils.IsEmpty(threadTS) && !utils.IsEmpty(mOrigin.ParentID()) {
+				threadTS = mOrigin.ParentID()
+			}
 			r = s.buildResponse(false, append(s.messageResponses(mOrigin, true), response)...)
 		}
 	}


### PR DESCRIPTION
In some cases, as stated in the comment in slack.go, line 2833, mOrigin.key is nil, and that means that threadTS doesn't have a chance to be set. 
I added a piece of code that allows threadTS to be set to the parent message's ts even if its key is nil. 