### PR TITLE
Fix postTemplates execution on scheduled messages

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -4117,6 +4117,7 @@ func (s *Slack) newJob(cmd common.Command) *slacker.JobDefinition {
 		mNew.blocks = blocks
 		mNew.actions = actions
 		mNew.visible = r.visible
+		mNew.SetParentID(mNew.ID())
 		s.putMessageToCache(mNew)
 
 		err = executor.After(mNew)


### PR DESCRIPTION
When posting a message through a schedule in Chatops, all subsequent postTemplates are not posted inside the parent's thread, but on the channel as separate messages.

In this change, we set the message parent ID before we call `executor.After()`, thus making sure that when we loop through the posts, `de.bot.PostMessage()` can set the threadTs to the parent ID (slack.go, line 3306).
