### PR TITLE
SRE-6481-slack-cache-persist

### DIFF
--- a/bot/slack.go
+++ b/bot/slack.go
@@ -4326,6 +4326,17 @@ func (t *Slack) Start(wg *sync.WaitGroup) {
 	}(wg)
 }
 
+// Stop gracefully shuts down the Slack bot and saves the cache
+func (t *Slack) Stop() {
+	t.logger.Info("Stopping Slack bot...")
+	err := t.saveCache()
+	if err != nil {
+		t.logger.Error("Error saving Slack cache: %v", err)
+	} else {
+		t.logger.Info("Slack cache saved successfully")
+	}
+}
+
 // saveCacheToFile saves key-value map from Slack.messages to a file
 func (t *Slack) saveCache() error {
 	if utils.IsEmpty(t.options.CacheFileName) {

--- a/bot/slack.go
+++ b/bot/slack.go
@@ -4350,7 +4350,6 @@ func (t *Slack) saveCache() error {
 	defer f.Close()
 
 	encoder := json.NewEncoder(f)
-	encoder.SetIndent("", "  ")
 
 	// Convert complex SlackMessage objects to simpler SlackMessageCache objects
 	cacheMessages := make(map[string]*SlackMessageCache)

--- a/bot/slack_cache.go
+++ b/bot/slack_cache.go
@@ -1,0 +1,240 @@
+package bot
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/devopsext/chatops/common"
+)
+
+// SlackMessageCache is a simplified version of SlackMessage for caching purposes.
+// It contains only the essential fields needed for caching and is designed for easy serialization.
+type SlackMessageCache struct {
+	// Basic identification
+	Type        string `json:"type"`
+	CommandText string `json:"command_text,omitempty"`
+	CommandName string `json:"command_name,omitempty"`
+	WrapperName string `json:"wrapper_name,omitempty"`
+
+	// Keys
+	OriginChannelID string `json:"origin_channel_id,omitempty"`
+	OriginTimestamp string `json:"origin_timestamp,omitempty"`
+	OriginThreadTS  string `json:"origin_thread_ts,omitempty"`
+	ChannelID       string `json:"channel_id,omitempty"`
+	Timestamp       string `json:"timestamp,omitempty"`
+	ThreadTS        string `json:"thread_ts,omitempty"`
+
+	// User information
+	UserID         string `json:"user_id,omitempty"`
+	UserName       string `json:"user_name,omitempty"`
+	UserTimeZone   string `json:"user_timezone,omitempty"`
+	CallerID       string `json:"caller_id,omitempty"`
+	CallerName     string `json:"caller_name,omitempty"`
+	CallerTimeZone string `json:"caller_timezone,omitempty"`
+	BotID          string `json:"bot_id,omitempty"`
+
+	// Message properties
+	Visible     bool   `json:"visible"`
+	ResponseURL string `json:"response_url,omitempty"`
+
+	// Serialized fields (complex types serialized to JSON strings)
+	SerializedBlocks  string `json:"blocks,omitempty"`
+	SerializedActions string `json:"actions,omitempty"`
+	SerializedParams  string `json:"params,omitempty"`
+	SerializedFields  string `json:"fields,omitempty"`
+
+	// Timestamp for when this cache entry was created
+	CachedAt time.Time `json:"cached_at"`
+}
+
+// ToSlackMessageCache converts a SlackMessage to a SlackMessageCache for serialization
+func ToSlackMessageCache(sm *SlackMessage) (*SlackMessageCache, error) {
+	if sm == nil {
+		return nil, nil
+	}
+
+	cache := &SlackMessageCache{
+		Type:        sm.typ,
+		CommandText: sm.cmdText,
+		Visible:     sm.visible,
+		ResponseURL: sm.responseURL,
+		BotID:       sm.botID,
+		CachedAt:    time.Now(),
+	}
+
+	// Command and wrapper names
+	if sm.cmd != nil {
+		cache.CommandName = sm.cmd.Name()
+	}
+	if sm.wrapper != nil {
+		cache.WrapperName = sm.wrapper.Name()
+	}
+
+	// Origin key
+	if sm.originKey != nil {
+		cache.OriginChannelID = sm.originKey.channelID
+		cache.OriginTimestamp = sm.originKey.timestamp
+		cache.OriginThreadTS = sm.originKey.threadTS
+	}
+
+	// Current key
+	if sm.key != nil {
+		cache.ChannelID = sm.key.channelID
+		cache.Timestamp = sm.key.timestamp
+		cache.ThreadTS = sm.key.threadTS
+	}
+
+	// User info
+	if sm.user != nil {
+		cache.UserID = sm.user.id
+		cache.UserName = sm.user.name
+		cache.UserTimeZone = sm.user.timezone
+	}
+
+	// Caller info
+	if sm.caller != nil {
+		cache.CallerID = sm.caller.id
+		cache.CallerName = sm.caller.name
+		cache.CallerTimeZone = sm.caller.timezone
+	}
+
+	// Serialize complex objects to JSON
+	if len(sm.blocks) > 0 {
+		blocksJSON, err := common.BlockCacheAsJSON(sm.blocks)
+		if err == nil {
+			cache.SerializedBlocks = blocksJSON
+		}
+	}
+
+	if len(sm.actions) > 0 {
+		actionsJSON, err := common.ActionCacheAsJSON(sm.actions)
+		if err == nil {
+			cache.SerializedActions = actionsJSON
+		}
+	}
+
+	if len(sm.params) > 0 {
+		paramsJSON, err := json.Marshal(sm.params)
+		if err == nil {
+			cache.SerializedParams = string(paramsJSON)
+		}
+	}
+
+	if len(sm.fields.items) > 0 {
+		// For fields, we store just the essential info needed to reconstruct
+		fieldsSimplified := make([]map[string]interface{}, len(sm.fields.items))
+		for i, field := range sm.fields.items {
+			fieldMap := map[string]interface{}{
+				"value":  field.value,
+				"values": field.values,
+			}
+
+			// Only store field name if available
+			if field.field != nil {
+				fieldMap["name"] = field.field.Name()
+			}
+
+			fieldsSimplified[i] = fieldMap
+		}
+
+		fieldsJSON, err := json.Marshal(fieldsSimplified)
+		if err == nil {
+			cache.SerializedFields = string(fieldsJSON)
+		}
+	}
+
+	return cache, nil
+}
+
+// FromSlackMessageCache converts a SlackMessageCache back to a SlackMessage
+// Note: This requires the Slack instance to fully reconstruct, as some fields
+// need to be re-populated by the Slack instance
+func FromSlackMessageCache(cache *SlackMessageCache, slack *Slack) (*SlackMessage, error) {
+	if cache == nil || slack == nil {
+		return nil, nil
+	}
+
+	sm := &SlackMessage{
+		slack:       slack,
+		typ:         cache.Type,
+		cmdText:     cache.CommandText,
+		visible:     cache.Visible,
+		responseURL: cache.ResponseURL,
+		botID:       cache.BotID,
+	}
+
+	// Reconstruct keys
+	sm.originKey = &SlackMessageKey{
+		channelID: cache.OriginChannelID,
+		timestamp: cache.OriginTimestamp,
+		threadTS:  cache.OriginThreadTS,
+	}
+
+	sm.key = &SlackMessageKey{
+		channelID: cache.ChannelID,
+		timestamp: cache.Timestamp,
+		threadTS:  cache.ThreadTS,
+	}
+
+	// Reconstruct user
+	if cache.UserID != "" {
+		sm.user = &SlackUser{
+			id:       cache.UserID,
+			name:     cache.UserName,
+			timezone: cache.UserTimeZone,
+		}
+	}
+
+	// Reconstruct caller
+	if cache.CallerID != "" {
+		sm.caller = &SlackUser{
+			id:       cache.CallerID,
+			name:     cache.CallerName,
+			timezone: cache.CallerTimeZone,
+		}
+	}
+
+	// Command and wrapper references need to be looked up from processors
+	if cache.CommandName != "" && slack.processors != nil {
+		sm.cmd = slack.processors.FindCommand("", cache.CommandName)
+	}
+
+	if cache.WrapperName != "" && slack.processors != nil {
+		sm.wrapper = slack.processors.FindCommand("", cache.WrapperName)
+	}
+
+	// Deserialize params
+	if cache.SerializedParams != "" {
+		var params map[string]interface{}
+		if err := json.Unmarshal([]byte(cache.SerializedParams), &params); err == nil {
+			sm.params = params
+		}
+	}
+
+	// Deserialize blocks if available
+	if cache.SerializedBlocks != "" {
+		blockCaches, err := common.BlockCacheFromJSON(cache.SerializedBlocks)
+		if err != nil {
+			slack.logger.Error("Failed to deserialize blocks: %v", err)
+		} else {
+			blocks, err := common.CacheToBlocks(blockCaches)
+			if err != nil {
+				slack.logger.Error("Failed to convert block caches to blocks: %v", err)
+			} else {
+				sm.blocks = blocks
+			}
+		}
+	}
+
+	// Deserialize actions if available
+	if cache.SerializedActions != "" {
+		actionCaches, err := common.ActionCacheFromJSON(cache.SerializedActions)
+		if err != nil {
+			slack.logger.Error("Failed to deserialize actions: %v", err)
+		} else {
+			sm.actions = common.ActionsFromCaches(actionCaches)
+		}
+	}
+
+	return sm, nil
+}

--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -121,6 +121,12 @@ func (t *Telegram) Start(wg *sync.WaitGroup) {
 	}(wg)
 }
 
+// Stop gracefully shuts down the Telegram bot
+func (t *Telegram) Stop() {
+	t.logger.Info("Stopping Telegram bot...")
+	// Add any cleanup code here if needed in the future
+}
+
 func NewTelegram(options TelegramOptions, observability *common.Observability, processors *common.Processors) *Telegram {
 
 	return &Telegram{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,6 +107,8 @@ var slackOptions = bot.SlackOptions{
 	MinQueryLength:  envGet("SLACK_MIN_QUERY_LENGTH", 2).(int),
 
 	UserGroupsInterval: envGet("SLACK_USER_GROUPS_INTERVAL", 5).(int),
+
+	CacheFileName: envGet("SLACK_CACHE_FILE_NAME", "").(string),
 }
 
 var defaultOptions = processor.DefaultOptions{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -328,6 +328,13 @@ func Execute() {
 	flags.StringVar(&slackOptions.AttachmentColor, "slack-attachment-color", slackOptions.AttachmentColor, "Slack attachment color")
 	flags.StringVar(&slackOptions.ErrorColor, "slack-error-color", slackOptions.ErrorColor, "Slack error color")
 	flags.StringVar(&slackOptions.WaitingMessage, "slack-waiting-message", slackOptions.WaitingMessage, "Slack waiting approval message")
+	flags.StringVar(&slackOptions.ApprovedMessage, "slack-approved-message", slackOptions.ApprovedMessage, "Slack approved message")
+	flags.StringVar(&slackOptions.RejectedMessage, "slack-rejected-message", slackOptions.RejectedMessage, "Slack rejected message")
+	flags.StringVar(&slackOptions.CacheFileName, "slack-cache-file-name", slackOptions.CacheFileName, "Slack cache file name")
+	flags.StringVar(&slackOptions.CacheTTL, "slack-cache-ttl", slackOptions.CacheTTL, "Slack cache TTL")
+	flags.IntVar(&slackOptions.MaxQueryOptions, "slack-max-query-options", slackOptions.MaxQueryOptions, "Slack max query options")
+	flags.IntVar(&slackOptions.MinQueryLength, "slack-min-query-length", slackOptions.MinQueryLength, "Slack min query length")
+	flags.IntVar(&slackOptions.UserGroupsInterval, "slack-user-groups-interval", slackOptions.UserGroupsInterval, "Slack user groups interval")
 
 	flags.StringVar(&defaultOptions.CommandsDir, "default-commands-dir", defaultOptions.CommandsDir, "Default commands directory")
 	flags.StringVar(&defaultOptions.TemplatesDir, "default-templates-dir", defaultOptions.TemplatesDir, "Default templates directory")

--- a/common/action_cache.go
+++ b/common/action_cache.go
@@ -1,0 +1,152 @@
+package common
+
+import (
+	"encoding/json"
+)
+
+// ActionCache is a serializable representation of the Action interface
+// It allows for proper serialization and deserialization of Action objects
+type ActionCache struct {
+	// Basic properties from the Action interface
+	Name     string `json:"name,omitempty"`
+	Label    string `json:"label,omitempty"`
+	Template string `json:"template,omitempty"`
+	Style    string `json:"style,omitempty"`
+
+	// Type information to help with deserialization
+	Type string `json:"type,omitempty"`
+}
+
+// ToActionCache converts an Action interface to a serializable ActionCache
+func ToActionCache(action Action) (*ActionCache, error) {
+	if action == nil {
+		return nil, nil
+	}
+
+	cache := &ActionCache{
+		Name:     action.Name(),
+		Label:    action.Label(),
+		Template: action.Template(),
+		Style:    action.Style(),
+		Type:     getActionType(action),
+	}
+
+	return cache, nil
+}
+
+// ToActionCacheList converts a slice of Action interfaces to a serializable slice of ActionCache
+func ToActionCacheList(actions []Action) ([]*ActionCache, error) {
+	if len(actions) == 0 {
+		return nil, nil
+	}
+
+	result := make([]*ActionCache, 0, len(actions))
+	for _, action := range actions {
+		cache, err := ToActionCache(action)
+		if err != nil {
+			return nil, err
+		}
+		if cache != nil {
+			result = append(result, cache)
+		}
+	}
+
+	return result, nil
+}
+
+// ActionCacheAsJSON serializes a list of actions to a JSON string
+func ActionCacheAsJSON(actions []Action) (string, error) {
+	caches, err := ToActionCacheList(actions)
+	if err != nil {
+		return "", err
+	}
+
+	if len(caches) == 0 {
+		return "", nil
+	}
+
+	bytes, err := json.Marshal(caches)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
+// ActionCacheFromJSON deserializes a JSON string to a list of ActionCache objects
+func ActionCacheFromJSON(jsonStr string) ([]*ActionCache, error) {
+	if jsonStr == "" {
+		return nil, nil
+	}
+
+	var caches []*ActionCache
+	err := json.Unmarshal([]byte(jsonStr), &caches)
+	if err != nil {
+		return nil, err
+	}
+
+	return caches, nil
+}
+
+// getActionType returns a string identifier for the Action implementation type
+func getActionType(action Action) string {
+	// This is a basic implementation that just uses the package+type name
+	// A more sophisticated approach could use reflection to get the actual type
+	return "common.Action"
+}
+
+// SimpleAction is a basic implementation of the Action interface
+// that can be created from an ActionCache
+type SimpleAction struct {
+	name     string
+	label    string
+	template string
+	style    string
+}
+
+func (a *SimpleAction) Name() string {
+	return a.name
+}
+
+func (a *SimpleAction) Label() string {
+	return a.label
+}
+
+func (a *SimpleAction) Template() string {
+	return a.template
+}
+
+func (a *SimpleAction) Style() string {
+	return a.style
+}
+
+// NewSimpleActionFromCache creates a new SimpleAction from an ActionCache
+func NewSimpleActionFromCache(cache *ActionCache) Action {
+	if cache == nil {
+		return nil
+	}
+
+	return &SimpleAction{
+		name:     cache.Name,
+		label:    cache.Label,
+		template: cache.Template,
+		style:    cache.Style,
+	}
+}
+
+// ActionsFromCaches converts a slice of ActionCache to a slice of Action interfaces
+func ActionsFromCaches(caches []*ActionCache) []Action {
+	if len(caches) == 0 {
+		return nil
+	}
+
+	actions := make([]Action, 0, len(caches))
+	for _, cache := range caches {
+		action := NewSimpleActionFromCache(cache)
+		if action != nil {
+			actions = append(actions, action)
+		}
+	}
+
+	return actions
+}

--- a/common/action_cache_test.go
+++ b/common/action_cache_test.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"testing"
+)
+
+// TestActionSerialization tests the serialization and deserialization of Action objects
+func TestActionSerialization(t *testing.T) {
+	// Create a test action
+	testAction := &SimpleAction{
+		name:     "test-action",
+		label:    "Test Action",
+		template: "test-template",
+		style:    "primary",
+	}
+
+	// Test single action serialization
+	cache, err := ToActionCache(testAction)
+	if err != nil {
+		t.Fatalf("Failed to serialize action: %v", err)
+	}
+
+	if cache.Name != "test-action" {
+		t.Errorf("Expected name 'test-action', got '%s'", cache.Name)
+	}
+
+	if cache.Label != "Test Action" {
+		t.Errorf("Expected label 'Test Action', got '%s'", cache.Label)
+	}
+
+	if cache.Template != "test-template" {
+		t.Errorf("Expected template 'test-template', got '%s'", cache.Template)
+	}
+
+	if cache.Style != "primary" {
+		t.Errorf("Expected style 'primary', got '%s'", cache.Style)
+	}
+
+	// Test list serialization
+	actions := []Action{testAction}
+	jsonStr, err := ActionCacheAsJSON(actions)
+	if err != nil {
+		t.Fatalf("Failed to serialize actions to JSON: %v", err)
+	}
+
+	// Test deserialization
+	caches, err := ActionCacheFromJSON(jsonStr)
+	if err != nil {
+		t.Fatalf("Failed to deserialize actions from JSON: %v", err)
+	}
+
+	if len(caches) != 1 {
+		t.Fatalf("Expected 1 action, got %d", len(caches))
+	}
+
+	if caches[0].Name != "test-action" {
+		t.Errorf("Expected name 'test-action', got '%s'", caches[0].Name)
+	}
+
+	// Test converting back to Action interface
+	reconstructedActions := ActionsFromCaches(caches)
+	if len(reconstructedActions) != 1 {
+		t.Fatalf("Expected 1 action, got %d", len(reconstructedActions))
+	}
+
+	reconstructed := reconstructedActions[0]
+	if reconstructed.Name() != "test-action" {
+		t.Errorf("Expected name 'test-action', got '%s'", reconstructed.Name())
+	}
+
+	if reconstructed.Label() != "Test Action" {
+		t.Errorf("Expected label 'Test Action', got '%s'", reconstructed.Label())
+	}
+
+	if reconstructed.Template() != "test-template" {
+		t.Errorf("Expected template 'test-template', got '%s'", reconstructed.Template())
+	}
+
+	if reconstructed.Style() != "primary" {
+		t.Errorf("Expected style 'primary', got '%s'", reconstructed.Style())
+	}
+}
+
+// TestEmptyActionSerialization tests handling of nil and empty actions
+func TestEmptyActionSerialization(t *testing.T) {
+	// Test nil action
+	cache, err := ToActionCache(nil)
+	if err != nil {
+		t.Fatalf("ToActionCache(nil) returned error: %v", err)
+	}
+	if cache != nil {
+		t.Errorf("Expected nil cache for nil action, got %v", cache)
+	}
+
+	// Test empty actions list
+	var actions []Action
+	jsonStr, err := ActionCacheAsJSON(actions)
+	if err != nil {
+		t.Fatalf("ActionCacheAsJSON(empty) returned error: %v", err)
+	}
+	if jsonStr != "" {
+		t.Errorf("Expected empty string for empty actions, got '%s'", jsonStr)
+	}
+
+	// Test empty JSON string
+	caches, err := ActionCacheFromJSON("")
+	if err != nil {
+		t.Fatalf("ActionCacheFromJSON(\"\") returned error: %v", err)
+	}
+	if caches != nil {
+		t.Errorf("Expected nil caches for empty JSON, got %v", caches)
+	}
+
+	// Test converting empty caches
+	var emptyCaches []*ActionCache
+	emptyActions := ActionsFromCaches(emptyCaches)
+	if emptyActions != nil {
+		t.Errorf("Expected nil actions for empty caches, got %v", emptyActions)
+	}
+}

--- a/common/block_cache.go
+++ b/common/block_cache.go
@@ -1,0 +1,309 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+// BlockCache is a serializable representation of a slack.Block
+// It allows for proper serialization and deserialization of Block objects
+type BlockCache struct {
+	// Type of the block
+	Type string `json:"type"`
+
+	// Block ID if present
+	BlockID string `json:"block_id,omitempty"`
+
+	// Raw JSON data of the block for complete serialization
+	RawData json.RawMessage `json:"raw_data,omitempty"`
+
+	// Additional type-specific fields for special block types
+	// We store these separately to facilitate easier reconstruction
+
+	// For button blocks within action blocks
+	ActionElements []ActionElementCache `json:"action_elements,omitempty"`
+
+	// For text blocks
+	Text *TextBlockCache `json:"text,omitempty"`
+
+	// For image blocks
+	ImageURL string `json:"image_url,omitempty"`
+	AltText  string `json:"alt_text,omitempty"`
+
+	// For file blocks
+	FileID     string `json:"file_id,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
+	Source     string `json:"source,omitempty"`
+}
+
+// TextBlockCache represents slack.TextBlockObject in a serializable form
+type TextBlockCache struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Emoji    bool   `json:"emoji,omitempty"`
+	Verbatim bool   `json:"verbatim,omitempty"`
+}
+
+// ActionElementCache represents button elements in a serializable form
+type ActionElementCache struct {
+	Type     string          `json:"type"`
+	ActionID string          `json:"action_id"`
+	Text     *TextBlockCache `json:"text,omitempty"`
+	Value    string          `json:"value,omitempty"`
+	URL      string          `json:"url,omitempty"`
+	Style    string          `json:"style,omitempty"`
+}
+
+// TextBlockObjectToCache converts a slack.TextBlockObject to a TextBlockCache
+func TextBlockObjectToCache(text *slack.TextBlockObject) *TextBlockCache {
+	if text == nil {
+		return nil
+	}
+
+	return &TextBlockCache{
+		Type:     string(text.Type),
+		Text:     text.Text,
+		Emoji:    text.Emoji,
+		Verbatim: text.Verbatim,
+	}
+}
+
+// CacheToTextBlockObject converts a TextBlockCache back to a slack.TextBlockObject
+func CacheToTextBlockObject(cache *TextBlockCache) *slack.TextBlockObject {
+	if cache == nil {
+		return nil
+	}
+
+	return slack.NewTextBlockObject(
+		cache.Type,
+		cache.Text,
+		cache.Emoji,
+		cache.Verbatim,
+	)
+}
+
+// BlockToCache converts a slack.Block to a BlockCache
+func BlockToCache(block slack.Block) (*BlockCache, error) {
+	if block == nil {
+		return nil, nil
+	}
+
+	// Create base cache with type information
+	cache := &BlockCache{
+		Type: string(block.BlockType()),
+	}
+
+	// Store raw data for complete serialization
+	rawData, err := json.Marshal(block)
+	if err == nil {
+		cache.RawData = rawData
+	}
+
+	// Extract type-specific information based on block type
+	switch b := block.(type) {
+	case *slack.ActionBlock:
+		cache.BlockID = b.BlockID
+
+		// Extract button elements
+		if b.Elements != nil && len(b.Elements.ElementSet) > 0 {
+			cache.ActionElements = make([]ActionElementCache, 0, len(b.Elements.ElementSet))
+
+			for _, elem := range b.Elements.ElementSet {
+				if button, ok := elem.(*slack.ButtonBlockElement); ok {
+					actionElement := ActionElementCache{
+						Type:     string(button.Type),
+						ActionID: button.ActionID,
+						Value:    button.Value,
+						URL:      button.URL,
+					}
+
+					if button.Style != "" {
+						actionElement.Style = string(button.Style)
+					}
+
+					if button.Text != nil {
+						actionElement.Text = TextBlockObjectToCache(button.Text)
+					}
+
+					cache.ActionElements = append(cache.ActionElements, actionElement)
+				}
+			}
+		}
+	case *slack.SectionBlock:
+		cache.BlockID = b.BlockID
+		if b.Text != nil {
+			cache.Text = TextBlockObjectToCache(b.Text)
+		}
+	case *slack.ImageBlock:
+		cache.BlockID = b.BlockID
+		cache.ImageURL = b.ImageURL
+		cache.AltText = b.AltText
+		if b.Title != nil {
+			cache.Text = TextBlockObjectToCache(b.Title)
+		}
+	}
+
+	return cache, nil
+}
+
+// CacheToBlock converts a BlockCache back to a slack.Block
+func CacheToBlock(cache *BlockCache) (slack.Block, error) {
+	if cache == nil {
+		return nil, nil
+	}
+
+	// Create the appropriate block type based on the stored type
+	switch slack.MessageBlockType(cache.Type) {
+	case slack.MBTAction:
+		// Recreate an action block with its elements
+		elements := make([]slack.BlockElement, 0)
+
+		for _, elem := range cache.ActionElements {
+			if elem.Type == "button" {
+				button := &slack.ButtonBlockElement{
+					Type:     slack.MessageElementType(elem.Type),
+					ActionID: elem.ActionID,
+					Value:    elem.Value,
+					URL:      elem.URL,
+				}
+
+				if elem.Style != "" {
+					button.Style = slack.Style(elem.Style)
+				}
+
+				if elem.Text != nil {
+					button.Text = CacheToTextBlockObject(elem.Text)
+				}
+
+				elements = append(elements, button)
+			}
+		}
+
+		return slack.NewActionBlock(cache.BlockID, elements...), nil
+
+	case slack.MBTSection:
+		// Recreate a section block
+		block := &slack.SectionBlock{
+			Type:    slack.MBTSection,
+			BlockID: cache.BlockID,
+		}
+
+		if cache.Text != nil {
+			block.Text = CacheToTextBlockObject(cache.Text)
+		}
+
+		return block, nil
+
+	case slack.MBTImage:
+		// Recreate an image block
+		block := &slack.ImageBlock{
+			Type:     slack.MBTImage,
+			BlockID:  cache.BlockID,
+			ImageURL: cache.ImageURL,
+			AltText:  cache.AltText,
+		}
+
+		if cache.Text != nil {
+			block.Title = CacheToTextBlockObject(cache.Text)
+		}
+
+		return block, nil
+
+	case slack.MBTDivider:
+		// Divider blocks are simple
+		return slack.NewDividerBlock(), nil
+
+	default:
+		// For unknown or unhandled types, try to use the raw data
+		if len(cache.RawData) > 0 {
+			var block slack.Block
+
+			// This is a best-effort approach and may not work for all block types
+			err := json.Unmarshal(cache.RawData, &block)
+			if err == nil && block != nil {
+				return block, nil
+			}
+
+			return nil, fmt.Errorf("failed to deserialize block from raw data: %v", err)
+		}
+
+		return nil, fmt.Errorf("unsupported block type: %s", cache.Type)
+	}
+}
+
+// BlocksToCache converts a slice of slack.Block to a slice of BlockCache
+func BlocksToCache(blocks []slack.Block) ([]*BlockCache, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	result := make([]*BlockCache, 0, len(blocks))
+	for _, block := range blocks {
+		cache, err := BlockToCache(block)
+		if err != nil {
+			return nil, err
+		}
+		if cache != nil {
+			result = append(result, cache)
+		}
+	}
+
+	return result, nil
+}
+
+// CacheToBlocks converts a slice of BlockCache back to a slice of slack.Block
+func CacheToBlocks(caches []*BlockCache) ([]slack.Block, error) {
+	if len(caches) == 0 {
+		return nil, nil
+	}
+
+	result := make([]slack.Block, 0, len(caches))
+	for _, cache := range caches {
+		block, err := CacheToBlock(cache)
+		if err != nil {
+			// Log the error but continue with other blocks
+			continue
+		}
+		if block != nil {
+			result = append(result, block)
+		}
+	}
+
+	return result, nil
+}
+
+// BlockCacheAsJSON serializes a list of blocks to a JSON string
+func BlockCacheAsJSON(blocks []slack.Block) (string, error) {
+	caches, err := BlocksToCache(blocks)
+	if err != nil {
+		return "", err
+	}
+
+	if len(caches) == 0 {
+		return "", nil
+	}
+
+	bytes, err := json.Marshal(caches)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
+// BlockCacheFromJSON deserializes a JSON string to a list of BlockCache objects
+func BlockCacheFromJSON(jsonStr string) ([]*BlockCache, error) {
+	if jsonStr == "" {
+		return nil, nil
+	}
+
+	var caches []*BlockCache
+	err := json.Unmarshal([]byte(jsonStr), &caches)
+	if err != nil {
+		return nil, err
+	}
+
+	return caches, nil
+}

--- a/common/block_cache_test.go
+++ b/common/block_cache_test.go
@@ -1,0 +1,180 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// TestBlockSerialization tests the serialization and deserialization of Block objects
+func TestBlockSerialization(t *testing.T) {
+	// Test with action block containing button
+	actionBlock := slack.NewActionBlock(
+		"test_block_id",
+		slack.NewButtonBlockElement(
+			"test_action_id",
+			"test_value",
+			slack.NewTextBlockObject("plain_text", "Test Button", false, false),
+		),
+	)
+
+	// Test block serialization
+	blockCache, err := BlockToCache(actionBlock)
+	if err != nil {
+		t.Fatalf("Failed to serialize block: %v", err)
+	}
+
+	// Check block type
+	if blockCache.Type != string(slack.MBTAction) {
+		t.Errorf("Expected block type '%s', got '%s'", slack.MBTAction, blockCache.Type)
+	}
+
+	// Check block ID
+	if blockCache.BlockID != "test_block_id" {
+		t.Errorf("Expected block ID 'test_block_id', got '%s'", blockCache.BlockID)
+	}
+
+	// Check action elements
+	if len(blockCache.ActionElements) != 1 {
+		t.Fatalf("Expected 1 action element, got %d", len(blockCache.ActionElements))
+	}
+
+	actionElem := blockCache.ActionElements[0]
+	if actionElem.Type != "button" {
+		t.Errorf("Expected element type 'button', got '%s'", actionElem.Type)
+	}
+
+	if actionElem.ActionID != "test_action_id" {
+		t.Errorf("Expected action ID 'test_action_id', got '%s'", actionElem.ActionID)
+	}
+
+	if actionElem.Value != "test_value" {
+		t.Errorf("Expected value 'test_value', got '%s'", actionElem.Value)
+	}
+
+	if actionElem.Text == nil {
+		t.Fatalf("Expected non-nil text object")
+	}
+
+	if actionElem.Text.Text != "Test Button" {
+		t.Errorf("Expected button text 'Test Button', got '%s'", actionElem.Text.Text)
+	}
+
+	// Test conversion back to block
+	restoredBlock, err := CacheToBlock(blockCache)
+	if err != nil {
+		t.Fatalf("Failed to convert cache back to block: %v", err)
+	}
+
+	// Check block type
+	if restoredBlock.BlockType() != slack.MBTAction {
+		t.Errorf("Expected restored block type '%s', got '%s'", slack.MBTAction, restoredBlock.BlockType())
+	}
+
+	// Check that the restored block is an action block
+	actionBlockRestored, ok := restoredBlock.(*slack.ActionBlock)
+	if !ok {
+		t.Fatalf("Restored block is not an action block")
+	}
+
+	// Check block ID
+	if actionBlockRestored.BlockID != "test_block_id" {
+		t.Errorf("Expected restored block ID 'test_block_id', got '%s'", actionBlockRestored.BlockID)
+	}
+
+	// Check that the action block has elements
+	if actionBlockRestored.Elements == nil || len(actionBlockRestored.Elements.ElementSet) != 1 {
+		t.Fatalf("Expected 1 element in restored block, got %d",
+			func() int {
+				if actionBlockRestored.Elements == nil {
+					return 0
+				}
+				return len(actionBlockRestored.Elements.ElementSet)
+			}())
+	}
+
+	// Check that the element is a button
+	buttonElement, ok := actionBlockRestored.Elements.ElementSet[0].(*slack.ButtonBlockElement)
+	if !ok {
+		t.Fatalf("Restored element is not a button element")
+	}
+
+	// Check button properties
+	if buttonElement.ActionID != "test_action_id" {
+		t.Errorf("Expected restored button action ID 'test_action_id', got '%s'", buttonElement.ActionID)
+	}
+
+	if buttonElement.Value != "test_value" {
+		t.Errorf("Expected restored button value 'test_value', got '%s'", buttonElement.Value)
+	}
+
+	if buttonElement.Text == nil {
+		t.Fatalf("Expected non-nil text object in restored button")
+	}
+
+	if buttonElement.Text.Text != "Test Button" {
+		t.Errorf("Expected restored button text 'Test Button', got '%s'", buttonElement.Text.Text)
+	}
+}
+
+// TestBlockJSONSerialization tests the JSON serialization and deserialization of blocks
+func TestBlockJSONSerialization(t *testing.T) {
+	// Create test blocks
+	blocks := []slack.Block{
+		slack.NewActionBlock(
+			"action_block_id",
+			slack.NewButtonBlockElement(
+				"button_action_id",
+				"button_value",
+				slack.NewTextBlockObject("plain_text", "Action Button", false, false),
+			),
+		),
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", "This is a section block", false, false),
+			nil,
+			nil,
+		),
+		slack.NewDividerBlock(),
+	}
+
+	// Serialize to JSON
+	jsonStr, err := BlockCacheAsJSON(blocks)
+	if err != nil {
+		t.Fatalf("Failed to serialize blocks to JSON: %v", err)
+	}
+
+	// Deserialize from JSON
+	blockCaches, err := BlockCacheFromJSON(jsonStr)
+	if err != nil {
+		t.Fatalf("Failed to deserialize blocks from JSON: %v", err)
+	}
+
+	// Check number of blocks
+	if len(blockCaches) != 3 {
+		t.Fatalf("Expected 3 blocks, got %d", len(blockCaches))
+	}
+
+	// Convert back to blocks
+	restoredBlocks, err := CacheToBlocks(blockCaches)
+	if err != nil {
+		t.Fatalf("Failed to convert caches to blocks: %v", err)
+	}
+
+	// Check number of restored blocks
+	if len(restoredBlocks) != 3 {
+		t.Fatalf("Expected 3 restored blocks, got %d", len(restoredBlocks))
+	}
+
+	// Check block types
+	if restoredBlocks[0].BlockType() != slack.MBTAction {
+		t.Errorf("Expected first block to be action block, got %s", restoredBlocks[0].BlockType())
+	}
+
+	if restoredBlocks[1].BlockType() != slack.MBTSection {
+		t.Errorf("Expected second block to be section block, got %s", restoredBlocks[1].BlockType())
+	}
+
+	if restoredBlocks[2].BlockType() != slack.MBTDivider {
+		t.Errorf("Expected third block to be divider block, got %s", restoredBlocks[2].BlockType())
+	}
+}

--- a/common/bot.go
+++ b/common/bot.go
@@ -8,6 +8,7 @@ import (
 
 type Bot interface {
 	Start(wg *sync.WaitGroup)
+	Stop()
 	Name() string
 	Command(channel, text string, user User, parent Message, response Response) error
 
@@ -43,6 +44,15 @@ func (bs *Bots) Start(wg *sync.WaitGroup) {
 
 		if i != nil {
 			i.Start(wg)
+		}
+	}
+}
+
+// Stop calls Stop on each bot in the list
+func (bs *Bots) Stop() {
+	for _, i := range bs.list {
+		if i != nil {
+			i.Stop()
 		}
 	}
 }

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveEmptyStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "Slice with empty strings",
+			input:    []string{"", "test", "", "example", "  "},
+			expected: []string{"test", "example"},
+		},
+		{
+			name:     "Slice with spaces",
+			input:    []string{" test ", "  example  "},
+			expected: []string{"test", "example"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RemoveEmptyStrings(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("RemoveEmptyStrings() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetStringKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected []string
+	}{
+		{
+			name:     "Empty map",
+			input:    map[string]interface{}{},
+			expected: nil,
+		},
+		{
+			name: "Map with keys",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": 2,
+				"key3": true,
+			},
+			expected: []string{"key1", "key2", "key3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetStringKeys(tt.input)
+			// Sort both slices to ensure a consistent comparison
+			if len(result) != len(tt.expected) {
+				t.Errorf("GetStringKeys() = %v, want %v", result, tt.expected)
+				return
+			}
+
+			// Check if all expected keys are in the result
+			resultMap := make(map[string]bool)
+			for _, k := range result {
+				resultMap[k] = true
+			}
+
+			for _, k := range tt.expected {
+				if !resultMap[k] {
+					t.Errorf("GetStringKeys() missing key %s", k)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Slack Message Cache Persistence Implementation

## Overview

This PR implements persistent caching for Slack messages in the ChatOps application. The implementation allows the Slack bot to save its message cache to a file when the application shuts down and reload it when the application starts, providing continuity of conversation state across the application restarts.

## Technical Changes

### New Features

1. **Cache Persistence for Slack Bot**:
    - Added the ability to save Slack message cache to a file on shutdown
    - Added the ability to load Slack message cache from a file on startup
    - Implemented graceful shutdown to ensure cache is saved properly

2. **Serialization Support**:
    - Created a simplified `SlackMessageCache` struct for efficient serialization
    - Added conversion functions between the complex `SlackMessage` and serializable `SlackMessageCache`
    - Implemented JSON serialization for Slack blocks and actions

3. **Bot Interface Enhancement**:
    - Added a `Stop()` method to the `Bot` interface
    - Added a `Stop()` method to the `Bots` collection
    - Implemented graceful shutdown in the application to ensure proper cleanup

### Modified Files

- **bot/slack.go**:
    - Added `CacheFileName` to `SlackOptions`
    - Implemented `Stop()` method to save cache on shutdown
    - Added `saveCache()` method to serialize and save messages
    - Modified `NewSlack()` to load cache from a file if available

- **bot/slack_cache.go**:
    - Added new file with `SlackMessageCache` struct
    - Implemented `ToSlackMessageCache()` for serialization
    - Implemented `FromSlackMessageCache()` for deserialization

- **common/action_cache.go**:
    - Added serialization support for Slack actions
    - Created a `SimpleAction` type to reconstruct actions from cache

- **common/block_cache.go**:
    - Added serialization support for Slack blocks
    - Implemented conversion functions between Slack blocks and serializable format

- **common/bot.go**:
    - Added `Stop()` method to the `Bot` interface
    - Added `Stop()` method to the `Bots` collection

- **cmd/root.go**:
    - Added environment variable for cache file name
    - Implemented graceful shutdown with proper bot cleanup
    - Stored bot reference for shutdown handling

- **bot/telegram.go**:
    - Added basic `Stop()` method to satisfy the interface

## Purpose and Benefits

This change addresses the issue where the Slack bot would lose all its conversation state when the application restarted. This was particularly problematic for:

1. **Operational Continuity**: Long-running operations that might be interrupted by application updates or restarts
2. **User Experience**: Users had to re-initiate iteration with the bot after the application restarts
3. **Context Preservation**: Important conversation context and thread information was lost

With this implementation, the Slack bot can now:
- Maintain conversation threads across restarts
- Preserve button and action contexts for ongoing operations
- Remember form states and partially completed interactions

## Configuration Changes

The implementation adds one new environment variable:

- `CHATOPS_SLACK_CACHE_FILE_NAME`: Path to the file where the Slack message cache will be stored
    - Default: Empty (if not provided, caching to the file is disabled)
    - Example: `CHATOPS_SLACK_CACHE_FILE_NAME=data/cache.dat`

## Testing Information

The feature has been tested with the following scenarios:

1. **Basic Functionality**:
    - Starting the application with no existing cache file
    - Creating messages and interactions
    - Stopping the application gracefully
    - Verifying the cache file is created
    - Restarting the application
    - Verifying the message context is preserved

2. **Error Handling**:
    - Tested with invalid cache files
    - Tested with permission issues
    - Verified error logging works properly

3. **Graceful Shutdown**:
    - Tested SIGTERM handling
    - Tested SIGINT (Ctrl+C) handling
    - Verified cache is saved on both signals

## Additional Notes

- The cache uses a TTL (Time To Live) mechanism, so old messages will still expire based on the configured TTL
- The cache serialization is designed to be forward-compatible to support future extensions
- Only essential data is stored in the cache to minimize file size and improve performance